### PR TITLE
Fix theme toggle

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -14,16 +14,20 @@ theme:
     - navigation.top
     - content.code.copy
   palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: astral-light
       toggle:
-        icon: material/weather-sunny
+        icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: astral-dark
       toggle:
-        icon: material/weather-night
-        name: Switch to light mode
+        icon: material/brightness-4
+        name: Switch to system preference
   custom_dir: docs/.overrides
 repo_url: https://github.com/astral-sh/ruff
 repo_name: ruff


### PR DESCRIPTION
## Summary

This fixes the theme toggle so it has the most useful setting on by default: following the system dark/light mode

See https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode

## Test Plan

It follows the official docs exactly. If the docs get built for each PR branch, we can also check there if it works as intended.